### PR TITLE
refactor: rewrite to use async io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,15 +7,14 @@ dependencies = [
  "base64 0.13.0",
  "env_logger",
  "error-chain",
- "foreign-types 0.5.0",
  "hyper",
- "log 0.4.11",
- "openssl 0.10.30",
- "openssl-sys",
+ "log",
+ "openssl",
  "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -34,12 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,12 +42,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "antidote"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +49,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -87,13 +74,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.9.3"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -103,21 +86,21 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-
-[[package]]
-name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "byteorder"
-version = "1.3.4"
+name = "bumpalo"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
@@ -139,9 +122,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "core-foundation"
-version = "0.2.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -149,27 +132,24 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.2.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
+dependencies = [
+ "cfg-if 1.0.0",
+]
 
 [[package]]
 name = "env_logger"
@@ -179,7 +159,7 @@ checksum = "54532e3223c5af90a6a757c90b5c5521564b07e5e7a958681bcd2afad421cdcd"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.11",
+ "log",
  "regex",
  "termcolor",
 ]
@@ -191,8 +171,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "backtrace",
- "version_check 0.9.2",
+ "version_check",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -200,28 +186,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared 0.3.0",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f713f8b2aa9e24fec85b0e290c56caee12e3b6ae0aeeda238a75b28251afd6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -231,22 +196,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.3.0"
+name = "form_urlencoded"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684cf33bb7f28497939e8c7cf17e3e4e3b8d9a0080ffa4f8ae2f515442ee855"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
+name = "fuchsia-zircon"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
+
+[[package]]
+name = "futures-task"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project 1.0.1",
+ "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+
+[[package]]
+name = "h2"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "hermit-abi"
@@ -258,10 +313,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
 name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
@@ -271,44 +353,76 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.10.16"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
- "base64 0.9.3",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
- "language-tags",
- "log 0.3.9",
- "mime",
- "num_cpus",
- "time",
- "traitobject",
- "typeable",
- "unicase",
- "url",
+ "httpdate",
+ "itoa",
+ "pin-project 1.0.1",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
 ]
 
 [[package]]
-name = "hyper-native-tls"
-version = "0.2.4"
+name = "hyper-tls"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72332e4a35d3059583623b50e98e491b78f8b96c5521fcb3f428167955aa56e8"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "antidote",
+ "bytes",
  "hyper",
  "native-tls",
+ "tokio",
+ "tokio-tls",
 ]
 
 [[package]]
 name = "idna"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "indexmap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itoa"
@@ -317,16 +431,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
-name = "language-tags"
-version = "0.2.2"
+name = "js-sys"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
+checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
-name = "lazy_static"
-version = "0.2.11"
+name = "kernel32-sys"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
 
 [[package]]
 name = "lazy_static"
@@ -339,27 +460,6 @@ name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
-
-[[package]]
-name = "libflate"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
-dependencies = [
- "adler32",
- "crc32fast",
- "rle-decode-fast",
- "take_mut",
-]
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.11",
-]
 
 [[package]]
 name = "log"
@@ -384,11 +484,18 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "mime"
-version = "0.2.6"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
- "log 0.3.9",
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -402,18 +509,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.1.5"
+name = "mio"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "lazy_static 0.2.11",
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
  "libc",
- "openssl 0.9.24",
+ "log",
+ "miow",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a1cda389c26d6b88f3d2dc38aa1b750fe87d298cc5d795ec9e975f402f00372"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
  "schannel",
  "security-framework",
  "security-framework-sys",
- "tempdir",
+ "tempfile",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -434,30 +586,23 @@ checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "openssl"
-version = "0.9.24"
+version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
+checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
- "bitflags 0.9.1",
- "foreign-types 0.3.2",
- "lazy_static 1.4.0",
+ "bitflags",
+ "cfg-if 0.1.10",
+ "foreign-types",
+ "lazy_static",
  "libc",
  "openssl-sys",
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.30"
+name = "openssl-probe"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
-dependencies = [
- "bitflags 1.2.1",
- "cfg-if 0.1.10",
- "foreign-types 0.3.2",
- "lazy_static 1.4.0",
- "libc",
- "openssl-sys",
-]
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
@@ -474,15 +619,73 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+dependencies = [
+ "pin-project-internal 0.4.27",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+dependencies = [
+ "pin-project-internal 1.0.1",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
@@ -504,40 +707,50 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "fuchsia-cprng",
+ "getrandom",
  "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "rand_core 0.4.2",
+ "getrandom",
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.4.2"
+name = "rand_hc"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
-name = "rdrand"
-version = "0.4.0"
+name = "redox_syscall"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
@@ -563,30 +776,44 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.6.2"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d56dbe269dbe19d716b76ec8c3efce8ef84e974f5b7e5527463e8c0507d4e17"
+checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
 dependencies = [
+ "base64 0.12.3",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
  "hyper",
- "hyper-native-tls",
- "libflate",
- "log 0.3.9",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "tokio",
+ "tokio-tls",
  "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
 ]
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rustc-demangle"
@@ -601,27 +828,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
- "lazy_static 1.4.0",
- "winapi",
+ "lazy_static",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "security-framework"
-version = "0.1.16"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa44ee9c54ce5eecc9de7d5acbad112ee58755239381f687e564004ba4a2332"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
 dependencies = [
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -630,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.1.16"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -671,14 +893,32 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
  "dtoa",
  "itoa",
  "serde",
  "url",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "socket2"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -693,19 +933,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "take_mut"
-version = "0.2.2"
+name = "tempfile"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
  "rand",
+ "redox_syscall",
  "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -723,18 +961,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
- "lazy_static 1.4.0",
-]
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
+ "lazy_static",
 ]
 
 [[package]]
@@ -744,24 +971,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
+name = "tokio"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "slab",
+ "tokio-macros",
+]
 
 [[package]]
-name = "typeable"
-version = "0.1.2"
+name = "tokio-macros"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
+name = "tracing"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+dependencies = [
+ "cfg-if 0.1.10",
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project 0.4.27",
+ "tracing",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicase"
-version = "1.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.1.5",
+ "version_check",
 ]
 
 [[package]]
@@ -790,10 +1102,11 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "1.7.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
@@ -807,21 +1120,109 @@ checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-
-[[package]]
-name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+name = "want"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+dependencies = [
+ "cfg-if 0.1.10",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+dependencies = [
+ "cfg-if 0.1.10",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+
+[[package]]
+name = "web-sys"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
@@ -832,6 +1233,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -845,7 +1252,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -853,3 +1260,22 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ serde = {version = "1.0.117", features=["derive"]}
 serde_json = "1.0.59"
 serde_derive = "1.0"
 base64 = "0.13.0"
-hyper = "0.10.0"
-reqwest ="0.6"
+hyper = "0.13.9"
+reqwest = { version = "0.10.8", features = ["json"] }
 openssl = "0.10"
 env_logger = { version = "0.8.1"}
-foreign-types = { version = "0.5.0" }
-openssl-sys = { version = "0.9.28" }
+tokio = { version = "0.2", features = [ "time", "fs" ] }
 
 [dev-dependencies]
 env_logger = "0.8.1"
+tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
 
 [features]

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -7,7 +7,6 @@ use openssl::{pkey::PKey, x509::X509Req};
 use reqwest::Client;
 use reqwest::{header::CONTENT_TYPE, Response};
 use serde::{Deserialize, Serialize};
-use serde_json::from_str;
 use std::path::Path;
 use std::pin::Pin;
 use tokio::fs;
@@ -107,8 +106,7 @@ impl<'a> CertificateSigner<'a> {
 
 impl FinalizeResponse {
     async fn from_response(res: Response) -> Result<Self> {
-        let res_content = res.text().await?;
-        Ok(from_str(&res_content)?)
+        Ok(res.json().await?)
     }
 
     async fn get_certificates(&self, account: &Account) -> Result<Vec<X509>> {

--- a/src/challenge.rs
+++ b/src/challenge.rs
@@ -1,25 +1,24 @@
-
-use crate::{ContentType, jwt::Jws};
-use crate::Client;
 use crate::Account;
-use crate::File;
-use crate::Path;
+use crate::Client;
 use crate::Identifier;
-use std::io::{Write, Read};
+use crate::Path;
+use crate::{jwt::Jws, CONTENT_TYPE};
+use std::time::Duration;
 
-use openssl::hash::{hash, MessageDigest};
 use crate::helper::*;
 use log::debug;
-use reqwest::{Response, StatusCode};
+use openssl::hash::{hash, MessageDigest};
+use reqwest::StatusCode;
+use tokio::fs;
 
-use crate::error::{Result, ErrorKind};
-use serde::{Serialize, Deserialize};
+use crate::error::{ErrorKind, Result};
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 /// A verification challenge.
 pub struct Challenge {
     #[serde(skip)]
-    pub(crate) domain : Option<String>,
+    pub(crate) domain: Option<String>,
     /// Type of verification challenge. Usually `http-01`, `dns-01` for letsencrypt.
     #[serde(rename = "type")]
     pub(crate) ctype: String,
@@ -30,14 +29,14 @@ pub struct Challenge {
     /// Key authorization.
     pub(crate) status: String,
     #[serde(skip)]
-    pub(crate) key_authorization: String
+    pub(crate) key_authorization: String,
 }
 #[derive(Deserialize, Debug, Clone)]
 pub struct CheckResponse {
     pub(crate) status: String,
-    pub(crate) expires: String,    
+    pub(crate) expires: String,
     pub(crate) identifier: Identifier,
-    pub(crate) challenges: Vec<Challenge>
+    pub(crate) challenges: Vec<Challenge>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -47,19 +46,18 @@ struct ValidatePayload {
     pub(crate) token: String,
     pub(crate) resource: String,
     #[serde(rename = "keyAuthorization")]
-    pub(crate) key_authorization: String
+    pub(crate) key_authorization: String,
 }
 
 impl Challenge {
     /// Saves key authorization into `{path}/.well-known/acme-challenge/{token}` for http challenge.
-    pub fn save_key_authorization<P: AsRef<Path>>(&self, path: P) -> Result<()> {
-        use std::fs::create_dir_all;
+    pub async fn save_key_authorization<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        use tokio::fs::create_dir_all;
         let path = path.as_ref().join(".well-known").join("acme-challenge");
         debug!("Saving validation token into: {:?}", &path);
-        create_dir_all(&path)?;
+        create_dir_all(&path).await?;
 
-        let mut file = File::create(path.join(&self.token))?;
-        writeln!(&mut file, "{}", self.key_authorization)?;
+        fs::write(path.join(&self.token), self.key_authorization.as_bytes()).await?;
 
         Ok(())
     }
@@ -69,9 +67,10 @@ impl Challenge {
     /// This value is used for verification of domain over DNS. Signature must be saved
     /// as a TXT record for `_acme_challenge.example.com`.
     pub fn signature(&self) -> Result<String> {
-        Ok(b64(&hash(MessageDigest::sha256(),
-                     &self.key_authorization.clone().into_bytes())?))
-        
+        Ok(b64(&hash(
+            MessageDigest::sha256(),
+            &self.key_authorization.clone().into_bytes(),
+        )?))
     }
 
     pub fn domain(&self) -> Option<String> {
@@ -94,64 +93,59 @@ impl Challenge {
     }
 
     /// Triggers validation.
-    pub fn validate(&self, account: &Account) -> Result<()> {        
-        let payload = 
-            Jws::new(&self.url, account, ValidatePayload {
+    pub async fn validate(&self, account: &Account, poll_interval: Duration) -> Result<()> {
+        let payload = Jws::new(
+            &self.url,
+            account,
+            ValidatePayload {
                 ctype: self.ctype.clone(),
                 token: self.token.clone(),
                 resource: "challenge".into(),
-                key_authorization: self.key_authorization().to_string()
-            })?;        
+                key_authorization: self.key_authorization().to_string(),
+            },
+        )
+        .await?;
 
-        let client = Client::new()?;
+        let client = Client::new();
 
-        let mut resp = client.post(&self.url)
-            .header(ContentType("application/jose+json".parse().unwrap()))
-            .body(payload.to_string()?).send()?;
+        let resp = client
+            .post(&self.url)
+            .header(CONTENT_TYPE, "application/jose+json")
+            .body(payload.to_string()?)
+            .send()
+            .await?;
 
-        if resp.status() != &StatusCode::Accepted && resp.status() != &StatusCode::Ok {
-            return Err(ErrorKind::Msg("Unacceptable status when trying to validate".to_string()).into());
+        if resp.status() != StatusCode::ACCEPTED && resp.status() != StatusCode::OK {
+            return Err(
+                ErrorKind::Msg("Unacceptable status when trying to validate".to_string()).into(),
+            );
         }
 
-        let mut auth : Challenge = resp.into();
-        
+        let mut auth: Challenge = resp.json().await?;
+
         auth.key_authorization = self.key_authorization().to_string();
 
         loop {
             let status = &auth.status;
 
             if status == "pending" {
-                let mut resp = client
+                let jws = Jws::new(&auth.url, account, "").await?.to_string()?;
+
+                let resp = client
                     .post(&auth.url)
-                    .header(ContentType("application/jose+json".parse().unwrap()))
-                    .body({                        
-                        Jws::new(&auth.url,account, "")?.to_string()?
-                    })
-                    .send()?;
+                    .header(CONTENT_TYPE, "application/jose+json")
+                    .body(jws)
+                    .send()
+                    .await?;
 
-                    let mut res_content = String::new();
-                    
-                    resp.read_to_string(&mut res_content)?;
-
-                    auth = serde_json::from_str(&res_content)?;
-
+                auth = resp.json().await?;
             } else if status == "valid" {
-                
-                
                 return Ok(());
             } else if status == "invalid" {
                 return Err(ErrorKind::Msg("Invalid response.".into()).into());
             }
 
-            use std::thread::sleep;
-            use std::time::Duration;
-            sleep(Duration::from_secs(2));
+            tokio::time::delay_for(poll_interval).await
         }
-    }
-}
-
-impl From<Response> for Challenge {
-    fn from(mut response: Response) -> Self {
-        response.json().unwrap()
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-
 error_chain! {
     types {
         Error, ErrorKind, ChainErr, Result;
@@ -22,7 +21,6 @@ error_chain! {
         }
     }
 }
-
 
 fn acme_server_error_description(resp: &serde_json::Value) -> String {
     if let Some(obj) = resp.as_object() {

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -1,25 +1,15 @@
-
-
-
-
-
-use openssl::sign::Signer;
-use openssl::hash::{MessageDigest};
+use openssl::hash::MessageDigest;
 use openssl::pkey::PKey;
+use openssl::sign::Signer;
 
+use crate::{helper::b64, Account};
 
+use serde::{Deserialize, Serialize};
+use serde_json::to_string;
 
+use crate::error::Result;
 
-use crate::{Account, helper::{ b64 }};
-
-use serde_json::{ to_string };
-use serde::{Serialize, Deserialize};
-
-
-use crate::error::{Result};
-
-
-/// JwsHeader that is required for ACME2 
+/// JwsHeader that is required for ACME2
 /// kid is passed after an account is created / looked up
 /// jwk is passed for authorization
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -30,14 +20,14 @@ pub(crate) struct JwsHeader {
     #[serde(skip_serializing_if = "Option::is_none")]
     kid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    jwk: Option<Jwk>
+    jwk: Option<Jwk>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub(crate) struct Jwk {
     e: String,
     kty: String,
-    n: String
+    n: String,
 }
 
 impl Jwk {
@@ -45,111 +35,125 @@ impl Jwk {
         Jwk {
             e: b64(&pkey.rsa().unwrap().e().to_vec()),
             kty: "RSA".to_string(),
-            n: b64(&pkey.rsa().unwrap().n().to_vec())
+            n: b64(&pkey.rsa().unwrap().n().to_vec()),
         }
     }
 }
 
-
 #[derive(Serialize, Deserialize, Clone, Default)]
-pub(crate) struct Jws <T> where T : Serialize {
+pub(crate) struct Jws<T>
+where
+    T: Serialize,
+{
     #[serde(skip)]
     pub(crate) pkey: Option<PKey<openssl::pkey::Private>>,
     pub(crate) url: String,
     pub(crate) header: JwsHeader,
-    pub(crate) payload: T
+    pub(crate) payload: T,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 struct EncodedJws {
     pub(crate) payload: String,
     pub(crate) protected: String,
-    pub(crate) signature: String
+    pub(crate) signature: String,
 }
 
-impl <T> Jws <T> where T : Serialize {
+impl<T> Jws<T>
+where
+    T: Serialize,
+{
     pub(crate) fn to_string(&self) -> Result<String> {
         let pkey = self.pkey.as_ref().unwrap();
         let payload = to_string(&self.payload)?;
 
-        // a blank string is passed for some of the requests, which to_string turns into literally "" 
-        let payload64 = if payload == "\"\"" {"".into()} else { b64(&payload.into_bytes()) };
+        // a blank string is passed for some of the requests, which to_string turns into literally ""
+        let payload64 = if payload == "\"\"" {
+            "".into()
+        } else {
+            b64(&payload.into_bytes())
+        };
 
         let protected64 = b64(&to_string(&self.header)?.into_bytes());
 
         // signature: b64 of hash of signature of {proctected64}.{payload64}
         let signature64 = {
             let mut signer = Signer::new(MessageDigest::sha256(), pkey)?;
-            signer
-                .update(&format!("{}.{}", protected64, payload64).into_bytes())?;
+            signer.update(&format!("{}.{}", protected64, payload64).into_bytes())?;
             b64(&signer.sign_to_vec()?)
         };
 
         Ok(to_string(&EncodedJws {
             payload: payload64,
             protected: protected64,
-            signature: signature64
-        })?)    
+            signature: signature64,
+        })?)
     }
 
-    pub(crate) fn new(url: &str, account: &Account, payload: T) -> Result<Jws<T>> {    
-
+    pub(crate) async fn new(url: &str, account: &Account, payload: T) -> Result<Jws<T>> {
         let mut header: JwsHeader = JwsHeader::default();
-        header.nonce = account.directory.get_nonce()?;
+        header.nonce = account.directory.get_nonce().await?;
         header.alg = "RS256".into();
         header.url = url.into();
-        
+
         if let Some(kid) = account.pkey_id.clone() {
             header.kid = kid.into();
         } else {
             header.jwk = Some(Jwk::new(&account.pkey));
-        }   
+        }
 
         Ok(Jws {
             pkey: Some(account.pkey.clone()),
             header,
             payload,
-            url: url.into()            
+            url: url.into(),
         })
     }
 }
 
-
-
 #[cfg(test)]
 pub mod tests {
     extern crate env_logger;
+    use crate::error::*;
+    use crate::gen_key;
+    use crate::Account;
+    use crate::Directory;
     use crate::Jws;
-use crate::Account;
-use crate::Directory;
-use crate::gen_key;
-use crate::error::*;
 
-    const LETSENCRYPT_STAGING_DIRECTORY_URL: &'static str = "https://acme-staging-v02.api.letsencrypt.org/directory";
+    const LETSENCRYPT_STAGING_DIRECTORY_URL: &'static str =
+        "https://acme-staging-v02.api.letsencrypt.org/directory";
 
-    pub fn test_acc() -> Result<Account> {
-        Directory::from_url(LETSENCRYPT_STAGING_DIRECTORY_URL)?
+    pub async fn test_acc() -> Result<Account> {
+        Directory::from_url(LETSENCRYPT_STAGING_DIRECTORY_URL)
+            .await?
             .account_registration()
             .register()
+            .await
     }
 
-    #[test]
-    fn test_directory() -> Result<()>{
-        Directory::lets_encrypt()?;
+    #[tokio::test]
+    async fn test_directory() -> Result<()> {
+        Directory::lets_encrypt().await?;
 
-        let dir = Directory::from_url(LETSENCRYPT_STAGING_DIRECTORY_URL).unwrap();
-        
-        assert_eq!(dir.resources.new_account, "https://acme-staging-v02.api.letsencrypt.org/acme/new-acct");
+        let dir = Directory::from_url(LETSENCRYPT_STAGING_DIRECTORY_URL)
+            .await
+            .unwrap();
 
-        assert!(!dir.get_nonce().unwrap().is_empty());
+        assert_eq!(
+            dir.resources.new_account,
+            "https://acme-staging-v02.api.letsencrypt.org/acme/new-acct"
+        );
+
+        assert!(!dir.get_nonce().await.unwrap().is_empty());
 
         let pkey = gen_key().unwrap();
-        let account = dir.account_registration()
-            .pkey(pkey)
-            .register()?;
+        let account = dir.account_registration().pkey(pkey).register().await?;
 
-        assert!(Jws::new(&account.directory.resources.new_account,&account, "").is_ok());
+        assert!(
+            Jws::new(&account.directory.resources.new_account, &account, "")
+                .await
+                .is_ok()
+        );
         Ok(())
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,41 +1,40 @@
 #[macro_use]
 extern crate error_chain;
 
-use core::fmt::Display;
-use core::fmt::Debug;
-use crate::challenge::CheckResponse;
-use crate::challenge::Challenge;
 use crate::cert::CertificateSigner;
-use crate::hyperx::ReplayNonce;
-use crate::helper::get_raw;
-use jwt::{Jwk, Jws};
+use crate::challenge::Challenge;
+use crate::challenge::CheckResponse;
+use core::fmt::Debug;
+use core::fmt::Display;
 use helper::*;
-use log::{info};
+use jwt::{Jwk, Jws};
+use log::info;
 
 use register::AccountRegistration;
-use reqwest::header::Location;
-use hyper::header::ContentType;
-use std::{path::Path};
-use std::fs::File;
-use std::io::{Read, Write};
+use reqwest::header::CONTENT_TYPE;
+use reqwest::header::LOCATION;
 use std::collections::HashMap;
-
+use std::path::Path;
+use std::pin::Pin;
+use tokio::fs;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
 
 use openssl::hash::{hash, MessageDigest};
 use openssl::pkey::PKey;
-use openssl::x509::{X509};
+use openssl::x509::X509;
 
-use reqwest::{Client};
-use serde_json::{Value, to_string};
-use serde::{Serialize, Deserialize};
-use error::{Result};
+use error::Result;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{to_string, Value};
 
-mod jwt;
 pub mod cert;
-mod register;
-mod helper;
-mod error;
 mod challenge;
+pub mod error;
+mod helper;
+mod jwt;
+mod register;
 
 pub const LETSENCRYPT_DIRECTORY_URL: &'static str = "https://acme-v02.api.letsencrypt.org\
                                                      /directory";
@@ -45,8 +44,7 @@ pub const LETSENCRYPT_AGREEMENT_URL: &'static str = "https://letsencrypt.org/doc
 pub const LETSENCRYPT_INTERMEDIATE_CERT_URL: &'static str = "https://letsencrypt.org/certs/\
                                                              lets-encrypt-x3-cross-signed.pem";
 /// Default bit lenght for RSA keys and `X509_REQ`
-const BIT_LENGTH: u32 = 2048;                                                     
-      
+const BIT_LENGTH: u32 = 2048;
 
 /*pub mod prelude {
   pub use super::{Directory, Account, Challenge};
@@ -57,7 +55,7 @@ const BIT_LENGTH: u32 = 2048;
 struct DirectoryMetadata {
     caa_identities: Vec<String>,
     terms_of_service: String,
-    website:String,
+    website: String,
     #[serde(flatten)]
     other: HashMap<String, Value>,
 }
@@ -66,10 +64,10 @@ struct DirectoryMetadata {
 struct DirectoryResources {
     key_change: String,
     meta: DirectoryMetadata,
-    new_account:String,
-    new_nonce:String,
-    new_order:String,
-    revoke_cert:String,
+    new_account: String,
+    new_nonce: String,
+    new_order: String,
+    revoke_cert: String,
     #[serde(flatten)]
     other: HashMap<String, Value>,
 }
@@ -77,237 +75,247 @@ struct DirectoryResources {
 pub struct Directory {
     /// Base URL of directory
     url: String,
-    resources: DirectoryResources
+    resources: DirectoryResources,
 }
-
-#[macro_use] extern crate hyper;
-
-mod hyperx {
-
-    // ReplayNonce header for hyper
-    header! { (ReplayNonce, "Replay-Nonce") => [String] }
-}
-
 
 impl Directory {
-  /// Creates a Directory from
-  /// [`LETSENCRYPT_DIRECTORY_URL`](constant.LETSENCRYPT_DIRECTORY_URL.html).
-  pub fn lets_encrypt() -> Result<Directory> {
-      Directory::from_url(LETSENCRYPT_DIRECTORY_URL)
-  }
+    /// Creates a Directory from
+    /// [`LETSENCRYPT_DIRECTORY_URL`](constant.LETSENCRYPT_DIRECTORY_URL.html).
+    pub async fn lets_encrypt() -> Result<Directory> {
+        Directory::from_url(LETSENCRYPT_DIRECTORY_URL).await
+    }
 
-  /// Creates a Directory from directory URL.
-  ///
-  /// Example directory for testing `acme-client` crate with staging API:
-  ///
-  /// ```rust
-  /// # use acme_client::error::Result;
-  /// # fn try_main() -> Result<()> {
-  /// use acme_client::Directory;
-  /// let dir = Directory::from_url("https://acme-staging.api.letsencrypt.org/directory")?;
-  /// # Ok(()) }
-  /// # fn main () { try_main().unwrap(); }
-  /// ```
-  pub fn from_url(url: &str) -> Result<Directory> {    
-      let raw = &get_raw(url)?[..]; 
-      
-      Ok(Directory {
-             url: url.to_owned(),
-             resources: serde_json::from_str(&raw)?,
-         })
+    /// Creates a Directory from directory URL.
+    ///
+    /// Example directory for testing `acme-client` crate with staging API:
+    ///
+    /// ```rust
+    /// # use acme2_slim::error::Result;
+    /// # async fn try_main() -> Result<()> {
+    /// use acme2_slim::Directory;
+    /// let dir = Directory::from_url("https://acme-staging-v02.api.letsencrypt.org/directory").await?;
+    /// # Ok(()) }
+    /// # #[tokio::main]
+    /// # async fn main () { try_main().await.unwrap(); }
+    /// ```
+    pub async fn from_url(url: &str) -> Result<Directory> {
+        let client = Client::new();
 
-  }
+        let res = client.get(url).send().await?;
 
-  /// Consumes directory and creates new AccountRegistration.
-  ///
-  /// AccountRegistration is used to register an account.
-  ///
-  /// ```rust,no_run
-  /// # use acme_client::error::Result;
-  /// # fn try_main() -> Result<()> {
-  /// use acme_client::Directory;
-  ///
-  /// let directory = Directory::lets_encrypt()?;
-  /// let account = directory.account_registration()
-  ///                        .email("example@example.org")
-  ///                        .register()?;
-  /// # Ok(()) }
-  /// # fn main () { try_main().unwrap(); }
-  /// ```
-  pub fn account_registration(self) -> AccountRegistration {
-      AccountRegistration {
-          directory: self,
-          pkey: None,
-          email: None,
-          contact: None,
-          agreement: None,
-      }
-  }
+        let resources = res.json().await?;
 
-  pub fn new_account_url(&self) -> String {
-    self.resources.new_account.clone()
-  }
-  pub fn new_order_url(&self) -> String {
-    self.resources.new_order.clone()
-  }
-  
-  pub fn new_noince_url(&self) -> String {
-    self.resources.new_nonce.clone()
-  }
-  
-  pub fn revoke_cert_url(&self) -> String {
-    self.resources.revoke_cert.clone()
-  }
+        Ok(Directory {
+            url: url.to_owned(),
+            resources,
+        })
+    }
 
-  /// Gets nonce header from directory.
-  ///
-  fn get_nonce(&self) -> Result<String> {
-      let client = Client::new()?;
-      let res = client.get(&self.resources.new_nonce).send()?;
-      res.headers()
-          .get::<ReplayNonce>()
-          .ok_or("Replay-Nonce header not found".into())
-          .and_then(|nonce| Ok(nonce.as_str().to_string()))
-  }
+    /// Consumes directory and creates new AccountRegistration.
+    ///
+    /// AccountRegistration is used to register an account.
+    ///
+    /// ```rust,no_run
+    /// # use acme2_slim::error::Result;
+    /// # async fn try_main() -> Result<()> {
+    /// use acme2_slim::Directory;
+    ///
+    /// let directory = Directory::lets_encrypt().await?;
+    /// let account = directory.account_registration()
+    ///                        .email("example@example.org")
+    ///                        .register().await?;
+    /// # Ok(()) }
+    /// # #[tokio::main]
+    /// # async fn main () { try_main().await.unwrap(); }
+    /// ```
+    pub fn account_registration(self) -> AccountRegistration {
+        AccountRegistration {
+            directory: self,
+            pkey: None,
+            email: None,
+            contact: None,
+            agreement: None,
+        }
+    }
 
-  /// Makes a new post request to directory, signs payload with pkey.
-  ///
-  /// Returns the result struct that is deserialized from the result
-  fn request<'a, T: Serialize, E>(&self,
-                           account:&mut Account,
-                           url: &str,
-                           payload: T)
-                           -> Result<E> where for<'de> E : Deserialize<'de> {
+    pub fn new_account_url(&self) -> String {
+        self.resources.new_account.clone()
+    }
+    pub fn new_order_url(&self) -> String {
+        self.resources.new_order.clone()
+    }
 
-      let jws = Jws::new(url, account, payload)?;
+    pub fn new_noince_url(&self) -> String {
+        self.resources.new_nonce.clone()
+    }
 
-      let client = Client::new()?;
+    pub fn revoke_cert_url(&self) -> String {
+        self.resources.revoke_cert.clone()
+    }
 
-      let mut res = client
-          .post(url)
-          .header(ContentType("application/jose+json".parse().unwrap()))
-          .body(jws.to_string()?)
-          .send()?;
-      
-        let mut res_content = String::new();
-        res.read_to_string(&mut res_content)?;        
-      
-      if let Some(loc) = res.headers().get::<Location>() {            
-          if account.pkey_id.is_none() {
-            account.pkey_id = Some(loc.to_string());
-          }
-      }     
+    /// Gets nonce header from directory.
+    ///
+    async fn get_nonce(&self) -> Result<String> {
+        let client = Client::new();
+        let res = client.get(&self.resources.new_nonce).send().await?;
+        res.headers()
+            .get("Replay-Nonce")
+            .ok_or("Replay-Nonce header not found".into())
+            // TODO(lucacasonato): handle this error
+            .and_then(|nonce| Ok(nonce.to_str().unwrap().to_string()))
+    }
 
-      Ok(serde_json::from_str(&res_content)?)
-  }
+    /// Makes a new post request to directory, signs payload with pkey.
+    ///
+    /// Returns the result struct that is deserialized from the result
+    async fn request<'a, T: Serialize, E>(
+        &self,
+        account: &mut Account,
+        url: &str,
+        payload: T,
+    ) -> Result<E>
+    where
+        for<'de> E: Deserialize<'de>,
+    {
+        let jws = Jws::new(url, account, payload).await?;
+
+        let client = Client::new();
+
+        let res = client
+            .post(url)
+            .header(CONTENT_TYPE, "application/jose+json")
+            .body(jws.to_string()?)
+            .send()
+            .await?;
+
+        let maybe_loc = res.headers().get(LOCATION).cloned();
+
+        let res_content = res.text().await?;
+
+        if let Some(loc) = maybe_loc {
+            if account.pkey_id.is_none() {
+                // TODO(lucacasonato): handle this error
+                account.pkey_id = Some(loc.to_str().unwrap().to_string());
+            }
+        }
+
+        Ok(serde_json::from_str(&res_content)?)
+    }
 }
-
 
 pub struct Account {
     directory: Directory,
     pkey: PKey<openssl::pkey::Private>,
-    pkey_id: Option<String>
+    pkey_id: Option<String>,
 }
 
-#[derive(Clone,Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct RevokeResponse {
-    none: String
+    none: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 struct Identifier {
     #[serde(rename = "type")]
     itype: String,
-    value: String
+    value: String,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 struct FinalizeResponse {
     status: String,
     finalize: String,
-    certificate:String,
-    expires: String,    
-    authorizations:Vec<String>,
-    identifiers: Vec<Identifier>
+    certificate: String,
+    expires: String,
+    authorizations: Vec<String>,
+    identifiers: Vec<Identifier>,
 }
 
-
-#[derive(Clone,Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CreateOrderResponse {
     finalize_url: String,
     pub challenges: Vec<Challenge>,
-    pub domains: Vec<String>
+    pub domains: Vec<String>,
 }
 
 impl CreateOrderResponse {
     pub fn get_dns_challenges(&self) -> Vec<Challenge> {
-        self.challenges.iter()
+        self.challenges
+            .iter()
             .cloned()
             .filter(|p| p.ctype == "dns-01")
             .collect()
     }
 }
 
-#[derive(Clone,Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct NewOrderRequest {
-    identifiers: Vec<Identifier>
+    identifiers: Vec<Identifier>,
 }
 
-#[derive(Clone,Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct NewOrderResponse {
     status: String,
-    expires: String,    
+    expires: String,
     identifiers: Vec<Identifier>,
     authorizations: Vec<String>,
-    finalize: String
+    finalize: String,
 }
 
 impl Account {
     /// Creates a new identifier authorization object for domain
-    pub fn create_order<'a, T: AsRef<str> + Debug + Clone + Display>(&'a mut self, domains: &[T]) -> Result<CreateOrderResponse> {
-        info!("Sending identifier authorization request for {:?}", domains.to_vec());
+    pub async fn create_order<'a, T: AsRef<str> + Debug + Clone + Display>(
+        &'a mut self,
+        domains: &[T],
+    ) -> Result<CreateOrderResponse> {
+        info!(
+            "Sending identifier authorization request for {:?}",
+            domains.to_vec()
+        );
 
         let mut challenges: Vec<Challenge> = Vec::new();
 
         let req = NewOrderRequest {
             identifiers: {
-                domains.iter().map(|i| {
-                    Identifier {
+                domains
+                    .iter()
+                    .map(|i| Identifier {
                         itype: "dns".to_string(),
-                        value: i.to_string()
-                    }
-                }).collect()
-            }
+                        value: i.to_string(),
+                    })
+                    .collect()
+            },
         };
         let directory = self.directory().clone();
-        
+
         let new_order: NewOrderResponse = directory
-            .request(self, &directory.resources.new_order, req)?;
-                
-        for auth_url in new_order.authorizations {                 
-            let mut resp: CheckResponse = directory
-                .request(self, &auth_url,  "")?;
-                
+            .request(self, &directory.resources.new_order, req)
+            .await?;
+
+        for auth_url in new_order.authorizations {
+            let mut resp: CheckResponse = directory.request(self, &auth_url, "").await?;
+
             for challenge in resp.challenges.iter_mut() {
-                let key_authorization = format!("{}.{}",
-                challenge.token,
-                b64(&hash(MessageDigest::sha256(),
-                           &to_string(&Jwk::new(self.pkey()))?
-                                    .into_bytes())?));
+                let key_authorization = format!(
+                    "{}.{}",
+                    challenge.token,
+                    b64(&hash(
+                        MessageDigest::sha256(),
+                        &to_string(&Jwk::new(self.pkey()))?.into_bytes()
+                    )?)
+                );
                 challenge.key_authorization = key_authorization.clone();
                 challenge.domain = Some(resp.identifier.value.clone());
                 challenges.push(challenge.clone());
             }
-
-            
         }
-        
+
         Ok(CreateOrderResponse {
             finalize_url: new_order.finalize,
             challenges: challenges,
-            domains:domains.iter().map(|s| s.to_string()).collect()
+            domains: domains.iter().map(|s| s.to_string()).collect(),
         })
-    }       
+    }
 
     /// Creates a new `CertificateSigner` helper to sign a certificate for list of domains.
     ///
@@ -325,38 +333,37 @@ impl Account {
     }
 
     /// Revokes a signed certificate from pem formatted file
-    pub fn revoke_certificate_from_file<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
-        let content = {
-            let mut file = File::open(path)?;
-            let mut content = Vec::new();
-            file.read_to_end(&mut content)?;
-            content
-        };
+    pub async fn revoke_certificate_from_file<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+        let content = fs::read(path).await?;
         let cert = X509::from_pem(&content)?;
-        self.revoke_certificate(&cert)
+        self.revoke_certificate(&cert).await
     }
 
     /// Revokes a signed certificate
-    pub fn revoke_certificate(&mut self, cert: &X509) -> Result<()> {
+    pub async fn revoke_certificate(&mut self, cert: &X509) -> Result<()> {
         let mut map = HashMap::new();
         map.insert("certificate".to_owned(), b64(&cert.to_der()?));
         let directory = self.directory().clone();
 
-        let _response : RevokeResponse = directory
-            .request(self, &directory.resources.revoke_cert, map)?;
+        let _response: RevokeResponse = directory
+            .request(self, &directory.resources.revoke_cert, map)
+            .await?;
 
         Ok(())
     }
 
     /// Writes account private key to a writer
-    pub fn write_private_key<W: Write>(&self, writer: &mut W) -> Result<()> {
-        Ok(writer.write_all(&self.pkey().private_key_to_pem_pkcs8()?)?)
+    pub async fn write_private_key<W: AsyncWrite>(&self, mut writer: Pin<&mut W>) -> Result<()> {
+        writer
+            .write_all(&self.pkey().private_key_to_pem_pkcs8()?)
+            .await?;
+        Ok(())
     }
 
     /// Saves account private key to a file
-    pub fn save_private_key<P: AsRef<Path>>(&self, path: P) -> Result<()> {
-        let mut file = File::create(path)?;
-        self.write_private_key(&mut file)
+    pub async fn save_private_key<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        let mut file = fs::File::create(path).await?;
+        self.write_private_key(Pin::new(&mut file)).await
     }
 
     /// Returns a reference to account private key
@@ -370,22 +377,37 @@ impl Account {
     }
 }
 
-#[test]
-fn test_order() {
-    let _ = env_logger::init();
-    let mut account = jwt::tests::test_acc().unwrap();
-    let order = account
-        .create_order(&vec!["test.shangrila.dev"])
-        .unwrap();
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
 
-    for chal in order.get_dns_challenges() {
-        println!("Add {} to .acme-challenge.{}", chal.signature().unwrap(), &chal.domain.as_ref().unwrap());
-        
-        chal.validate(&account).unwrap();
+    #[tokio::test]
+    #[ignore]
+    async fn test_order() {
+        let _ = env_logger::init();
+        let mut account = crate::jwt::tests::test_acc().await.unwrap();
+        let order = account.create_order(&vec!["test.lcas.dev"]).await.unwrap();
+
+        for chal in order.get_dns_challenges() {
+            println!(
+                "Add {} to .acme-challenge.{}",
+                chal.signature().unwrap(),
+                &chal.domain.as_ref().unwrap()
+            );
+
+            chal.validate(&account, Duration::from_secs(5))
+                .await
+                .unwrap();
+        }
+
+        let signer = account.certificate_signer();
+
+        signer
+            .sign_certificate(&order)
+            .await
+            .unwrap()
+            .save_signed_certificate("tests/cert.pem")
+            .await
+            .unwrap();
     }
-
-    let signer = account.certificate_signer();
-
-    signer.sign_certificate(&order).unwrap().save_signed_certificate("tests/cert.pem")
-        .unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,8 +190,6 @@ impl Directory {
 
         let maybe_loc = res.headers().get(LOCATION).cloned();
 
-        let res_content = res.text().await?;
-
         if let Some(loc) = maybe_loc {
             if account.pkey_id.is_none() {
                 // TODO(lucacasonato): handle this error
@@ -199,7 +197,7 @@ impl Directory {
             }
         }
 
-        Ok(serde_json::from_str(&res_content)?)
+        Ok(res.json().await?)
     }
 }
 


### PR DESCRIPTION
This PR updates `reqwest` and `hyper`. These libraries are both now async. I have updated the entire library to be fully async because of this (saw it was on your roadmap anyway). This includes fs io, which is now handled by `tokio`.

Regarding all of the formatting changes, I have run `cargo fmt`.