### PR TITLE
Use supplied pkey and csr in CertificateSigner when provided

### DIFF
--- a/src/cert.rs
+++ b/src/cert.rs
@@ -75,8 +75,18 @@ impl<'a> CertificateSigner<'a> {
         info!("Signing certificate");
         let domains: Vec<&str> = order.domains.iter().map(|s| &s[..]).collect();
 
-        let pkey = gen_key()?;
-        let csr = gen_csr(&pkey, &domains)?;
+        let pkey = if let Some(pkey) = self.pkey {
+            pkey
+        } else {
+            gen_key()?
+        };
+
+        let csr = if let Some(csr) = self.csr {
+            csr
+        } else {
+            gen_csr(&pkey, &domains)?
+        };
+
         let payload = &csr.to_der()?;
 
         let csr_payload = CsrRequest { csr: b64(payload) };


### PR DESCRIPTION
I updated my project from using the acme-client project to use acme2-slim and noticed that the CertificateSigner::pkey and CertificateSigner::csr methods were no longer working and instead they would be freshly generated each time.

This change should change CertificateSigner to only generate a new pkey and csr if they have not already been provided.